### PR TITLE
Breaking Change: Update `loadTemplate` to take custom filters

### DIFF
--- a/example/example.hs
+++ b/example/example.hs
@@ -65,6 +65,21 @@ main = do
 -- to see 'HTML' and 'Tpl' + 'CSS' in action,
 -- respectively.
 --
+-- Example output:
+--
+-- curl -i -H 'Accept: text/html' http://localhost:8082/user
+-- HTTP/1.1 200 OK
+-- Transfer-Encoding: chunked
+-- Date: Thu, 15 Sep 2016 19:41:25 GMT
+-- Server: Warp/3.2.8
+-- Content-Type: text/html;charset=utf-8
+--
+-- <ul>
+-- <li><strong>Name</strong>: lambdabot</li>
+-- <li><strong>Age</strong>: 35</li>
+-- <li><strong>Chunked Name</strong>: ["l","a","m","b","d","a","b","o","t"]</li>
+-- </ul>
+--
 -- Feel free to tweak the content of the template files
 -- as well as the 'User' and 'CSSData' values in this program
 -- to see how it affects the rendering.

--- a/example/example.hs
+++ b/example/example.hs
@@ -9,6 +9,9 @@ import Network.HTTP.Media ((//))
 import Network.Wai.Handler.Warp
 import Servant
 import Servant.EDE
+import Text.EDE.Filters ((@:),Term)
+import qualified Data.HashMap.Strict as Map
+import Data.Text (Text, chunksOf)
 
 -- * Using 'Tpl' for rendering CSS templates
 
@@ -47,9 +50,12 @@ type API = StyleAPI :<|> UserAPI
 api :: Proxy API
 api = Proxy
 
+filters :: [(Text,Term)]
+filters = ["toChars" @: (chunksOf 1)]
+
 main :: IO ()
 main = do
-  loadTemplates api "example"
+  loadTemplates api filters "example"
   run 8082 (serve api $ styleServer :<|> userServer)
 
 -- You can now head to:

--- a/example/user.tpl
+++ b/example/user.tpl
@@ -1,4 +1,5 @@
 <ul>
 <li><strong>Name</strong>: {{ name }}</li>
 <li><strong>Age</strong>: {{ age }}</li>
+<li><strong>Chunked Name</strong>: {{ name | toChars | show }}</li>
 </ul>

--- a/servant-ede.cabal
+++ b/servant-ede.cabal
@@ -60,4 +60,6 @@ executable servant-ede-example
     , http-media
     , servant-server
     , servant-ede
+    , text
+    , unordered-containers
     , warp

--- a/src/Servant/EDE.hs
+++ b/src/Servant/EDE.hs
@@ -93,16 +93,19 @@ import qualified Data.Vector         as V
 -- This would try to load @home.tpl@, printing any error or
 -- registering the compiled template in a global (but safe)
 -- compiled template store, if successfully compiled.
+type Filters = (Text,Term)
 loadTemplates :: (Reify (TemplateFiles api), Applicative m, MonadIO m)
               => Proxy api
-              -> FilePath -- ^ root directory for the templates
+              -> [Filters] -- ^ list of (Text,Term) pairs. Pass [] to use just the standard library
+              -> FilePath  -- ^ root directory for the templates
               -> m Errors
-loadTemplates proxy dir = do
+loadTemplates proxy fpairs dir = do
   res <- loadTemplates' proxy dir
   case res of
     Left errs  -> return errs
     Right tpls -> do
-      liftIO $ putMVar __template_store tpls
+      let tplfs = TemplatesAndFilters tpls flts
+      liftIO $ putMVar __template_store tplfs
       return []
 
 loadTemplates' :: (Reify (TemplateFiles api), Applicative m, MonadIO m)

--- a/src/Servant/EDE.hs
+++ b/src/Servant/EDE.hs
@@ -193,11 +193,14 @@ instance Accept ct => Accept (Tpl ct file) where
 
 instance (KnownSymbol file, Accept ct, ToObject a) => MimeRender (Tpl ct file) a where
   mimeRender _ val = encodeUtf8 . result (error . show) id $
-    render templ (toObject val)
+    renderWith flts templ (toObject val)
 
     where templ = tmap ! filename
           filename = symbolVal (Proxy :: Proxy file)
-          tmap = templateMap $ unsafePerformIO (readMVar __template_store)
+          tmplfs = unsafePerformIO (readMVar __template_store)
+          tmap = templateMap $ _templates tmplfs
+          flts = _filters tmplfs
+
 
 __template_store :: MVar TemplatesAndFilters
 __template_store = unsafePerformIO newEmptyMVar

--- a/src/Servant/EDE.hs
+++ b/src/Servant/EDE.hs
@@ -75,6 +75,7 @@ import Text.HTML.SanitizeXSS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector         as V
 
+type Filter = (Text,Term)
 -- | This function initializes a global
 --   template store (i.e a 'Templates' value) and fills it with
 --   the resulting compiled templates if all of them are compiled
@@ -94,11 +95,10 @@ import qualified Data.Vector         as V
 -- This would try to load @home.tpl@, printing any error or
 -- registering the compiled template in a global (but safe)
 -- compiled template store, if successfully compiled.
-type Filters = (Text,Term)
 loadTemplates :: (Reify (TemplateFiles api), Applicative m, MonadIO m)
               => Proxy api
-              -> [Filters] -- ^ list of (Text,Term) pairs. Pass [] to use just the standard library
-              -> FilePath  -- ^ root directory for the templates
+              -> [Filter] -- ^ list of (Text,Term) pairs. Pass [] to use just the standard library
+              -> FilePath -- ^ root directory for the templates
               -> m Errors
 loadTemplates proxy fpairs dir = do
   let flts = fromList fpairs

--- a/src/Servant/EDE.hs
+++ b/src/Servant/EDE.hs
@@ -55,7 +55,7 @@ import Control.Concurrent
 import Control.Monad.IO.Class
 import Data.Aeson (Object, Value(..))
 import Data.Foldable (fold)
-import Data.HashMap.Strict (HashMap, (!))
+import Data.HashMap.Strict (HashMap, (!),fromList)
 import Data.Proxy
 import Data.Semigroup
 import Data.Text (Text)
@@ -69,6 +69,7 @@ import Servant.EDE.Internal.Validate
 import System.FilePath
 import System.IO.Unsafe
 import Text.EDE
+import Text.EDE.Filters (Term)
 import Text.HTML.SanitizeXSS
 
 import qualified Data.HashMap.Strict as HM
@@ -100,6 +101,7 @@ loadTemplates :: (Reify (TemplateFiles api), Applicative m, MonadIO m)
               -> FilePath  -- ^ root directory for the templates
               -> m Errors
 loadTemplates proxy fpairs dir = do
+  let flts = fromList fpairs
   res <- loadTemplates' proxy dir
   case res of
     Left errs  -> return errs

--- a/src/Servant/EDE.hs
+++ b/src/Servant/EDE.hs
@@ -196,7 +196,7 @@ instance (KnownSymbol file, Accept ct, ToObject a) => MimeRender (Tpl ct file) a
           filename = symbolVal (Proxy :: Proxy file)
           tmap = templateMap $ unsafePerformIO (readMVar __template_store)
 
-__template_store :: MVar Templates
+__template_store :: MVar TemplatesAndFilters
 __template_store = unsafePerformIO newEmptyMVar
 
 -- | 'HTML' content type, but more than just that.
@@ -319,6 +319,13 @@ instance Monoid Templates where
   mempty = Templates mempty
 
   a `mappend` b = a <> b
+
+-- A data type that holds both the compiled templates and
+-- any passed-in custom filters
+data TemplatesAndFilters = TemplatesAndFilters {
+                                  _templates :: Templates
+                                , _filters   :: HashMap Text Term
+                                }
 
 tpl :: FilePath -> Template -> Templates
 tpl fp t = Templates $ HM.singleton fp t

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.13
+resolver: lts-6.16
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
@alpmestan I took one shortcut in the design and hope that's ok. I noticed `Templates` was used in lots of different places -- including directory traversal output, etc.  

I did not find an easy way to update them all so I modified the `MVar` to take `TemplatesAndFilters`, which contains the filters and templates.  Let me know if my approach is not something you would recommend. 

I have also updated the example file and added example output in the comments. 
