### PR TITLE
Support GHC-9.4.8

### DIFF
--- a/src/Servant/EDE/Internal/Validate.hs
+++ b/src/Servant/EDE/Internal/Validate.hs
@@ -8,7 +8,6 @@ import Data.Traversable
 #endif
 
 import Data.Functor.Compose
-import Data.Semigroup
 
 data Validated e a = OK a | NotOK e
   deriving (Eq, Show)


### PR DESCRIPTION
This PR adds a support for GHC-9.4.8 and it should work on more recent versions as well.

However I've not checked problems on previous versions, and quite likely some Template Haskell should be added to keep support it of the older versions.